### PR TITLE
Added various asset factories

### DIFF
--- a/Plugins/BonamikPlugin/Source/BonamikEd/BonamikEd.Build.cs
+++ b/Plugins/BonamikPlugin/Source/BonamikEd/BonamikEd.Build.cs
@@ -12,6 +12,7 @@ public class BonamikEd : ModuleRules {
             "Engine",
             "BonamikRt",
             "UnrealEd",
+            "DeveloperSettings",
         });
     }
 }

--- a/Plugins/BonamikPlugin/Source/BonamikEd/Private/BonamikEdModule.cpp
+++ b/Plugins/BonamikPlugin/Source/BonamikEd/Private/BonamikEdModule.cpp
@@ -1,3 +1,27 @@
-#include "Modules/ModuleManager.h"
+#include "BonamikEdModule.h"
+#include "IAssetTools.h"
+#include "AssetToolsModule.h"
+#include "AssetTypeActions_BonamikWindAsset.h"
 
-IMPLEMENT_MODULE(FDefaultGameModuleImpl, BonamikEd);
+void FBonamikEdModule::StartupModule()
+{
+	FAssetToolsModule& AssetToolsModule = FAssetToolsModule::GetModule();
+
+	IAssetTools& AssetTools = AssetToolsModule.Get();
+
+	EAssetTypeCategories::Type CustomAssetCategory = AssetTools.RegisterAdvancedAssetCategory(FName("Bonamik"), FText::FromString("Bonamik"));
+	AssetAction = new FAssetTypeActions_BonamikWindAsset(CustomAssetCategory);
+	AssetTools.RegisterAssetTypeActions(MakeShareable(AssetAction));
+}
+
+void FBonamikEdModule::ShutdownModule()
+{
+	if (UObjectInitialized())
+	{
+		FAssetToolsModule& AssetToolsModule = FAssetToolsModule::GetModule();
+		IAssetTools& AssetTools = AssetToolsModule.Get();
+		AssetTools.UnregisterAssetTypeActions(AssetAction->AsShared());
+	}
+}
+
+IMPLEMENT_MODULE(FBonamikEdModule, BonamikEd)

--- a/Plugins/BonamikPlugin/Source/BonamikEd/Private/BonamikWindAsset_Factory.cpp
+++ b/Plugins/BonamikPlugin/Source/BonamikEd/Private/BonamikWindAsset_Factory.cpp
@@ -1,0 +1,54 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "BonamikWindAsset_Factory.h"
+
+#include "AssetToolsModule.h"
+#include "AssetTypeCategories.h"
+#include "IAssetTools.h"
+#include "SQEX_BonamikWind_Asset.h"
+
+#define LOCTEXT_NAMESPACE "UBonamikWindAsset_Factory"
+
+UBonamikWindAsset_Factory::UBonamikWindAsset_Factory()
+{
+	Formats.Add(TEXT("xml;BonamikWindAsset"));
+	bCreateNew = true;
+	bEditAfterNew = true;
+	bEditorImport = true;
+	SupportedClass = USQEX_BonamikWind_Asset::StaticClass();
+}
+
+FText UBonamikWindAsset_Factory::GetDisplayName() const
+{
+	return LOCTEXT("DisplayName", "Bonamik Wind Asset");
+}
+
+static bool bSoundFactorySuppressImportOverwriteDialog = false;
+
+uint32 UBonamikWindAsset_Factory::GetMenuCategories() const
+{
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	return AssetTools.RegisterAdvancedAssetCategory("Bonamik", LOCTEXT("AssetCategoryName", "Bonamik"));
+}
+
+UObject * UBonamikWindAsset_Factory::FactoryCreateNew(UClass * InClass, UObject * InParent, FName InName, EObjectFlags flags, UObject * Cntext, FFeedbackContext * Warn)
+{
+	return NewObject<USQEX_BonamikWind_Asset>(InParent, InClass, InName, flags);
+}
+
+bool UBonamikWindAsset_Factory::ShouldShowInNewMenu() const
+{
+	return true;
+}
+
+UObject* UBonamikWindAsset_Factory::FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled)
+{
+	FString PackagePath = FPackageName::GetLongPackagePath(InParent->GetOutermost()->GetName());
+
+	USQEX_BonamikWind_Asset* ImportedAsset = NewObject<USQEX_BonamikWind_Asset>(InParent, Name, Flags);
+	FString FilePath = FPaths::GetPath(CurrentFilename);
+	FPaths::MakePathRelativeTo(FilePath, *FPaths::ProjectDir());
+	return ImportedAsset;
+}
+
+#undef  LOCTEXT_NAMESPACE

--- a/Plugins/BonamikPlugin/Source/BonamikEd/Public/AssetTypeActions_BonamikWindAsset.h
+++ b/Plugins/BonamikPlugin/Source/BonamikEd/Public/AssetTypeActions_BonamikWindAsset.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AssetTypeCategories.h"
+#include "AssetTypeActions_Base.h"
+#include "SQEX_BonamikWind_Asset.h"
+
+class FAssetTypeActions_BonamikWindAsset : public FAssetTypeActions_Base
+{
+public:
+	FAssetTypeActions_BonamikWindAsset(EAssetTypeCategories::Type InAssetCategory)
+            : AssetCategory(InAssetCategory)
+        {}
+	// IAssetTypeActions Implementation
+	virtual FText GetName() const override { return NSLOCTEXT("AssetTypeActions", "AssetTypeActions_BonamikWindAsset", "Bonamik Wind Asset"); }
+	virtual FColor GetTypeColor() const override { return FColor::Magenta; }
+	virtual UClass* GetSupportedClass() const override { return USQEX_BonamikWind_Asset::StaticClass(); }
+	virtual uint32 GetCategories() override { return AssetCategory; }
+    
+private:
+    EAssetTypeCategories::Type AssetCategory;
+};

--- a/Plugins/BonamikPlugin/Source/BonamikEd/Public/BonamikEdModule.h
+++ b/Plugins/BonamikPlugin/Source/BonamikEd/Public/BonamikEdModule.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
+
+class FBonamikEdModule : public IModuleInterface
+{
+public:
+	FBonamikEdModule() {}
+	/** IModuleInterface implementation */
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+private:
+	class FAssetTypeActions_BonamikWindAsset* AssetAction;
+};

--- a/Plugins/BonamikPlugin/Source/BonamikEd/Public/BonamikWindAsset_Factory.h
+++ b/Plugins/BonamikPlugin/Source/BonamikEd/Public/BonamikWindAsset_Factory.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Factories/Factory.h"
+#include "EditorReimportHandler.h"
+#include "BonamikWindAsset_Factory.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class BONAMIKED_API UBonamikWindAsset_Factory : public UFactory
+{
+	GENERATED_BODY()
+	
+	UBonamikWindAsset_Factory();
+	virtual uint32 GetMenuCategories() const override;
+	virtual FText GetDisplayName() const override;
+	virtual UObject* FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Cntext, FFeedbackContext* Warn) override;
+	virtual bool ShouldShowInNewMenu() const override;
+	virtual UObject* FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled) override;
+};

--- a/Plugins/HappySadFaceLipSync/HappySadFaceLipSync.uplugin
+++ b/Plugins/HappySadFaceLipSync/HappySadFaceLipSync.uplugin
@@ -17,9 +17,20 @@
 	"Installed": false,
 	"Modules": [
 		{
+			"Name": "HSFLipSyncEditor",
+			"Type": "Developer",
+			"LoadingPhase": "Default"
+		},
+		{
 			"Name": "HSFLipSyncRuntime",
 			"Type": "Runtime",
 			"LoadingPhase": "Default"
+		}
+	],
+	"Plugins": [
+		{
+			"Name": "EditorScriptingUtilities",
+			"Enabled": true
 		}
 	]
 }

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/HSFLipSyncEditor.Build.cs
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/HSFLipSyncEditor.Build.cs
@@ -1,0 +1,73 @@
+// Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
+
+using UnrealBuildTool;
+using UnrealBuildTool.Rules;
+
+public class HSFLipSyncEditor : ModuleRules
+{
+	public HSFLipSyncEditor(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+		
+		PublicIncludePaths.AddRange(
+			new string[] {
+				"HSFLipSyncEditor/Public",
+				// ... add public include paths required here ...
+            }
+			);
+				
+		
+		PrivateIncludePaths.AddRange(
+			new string[] {
+				"HSFLipSyncEditor/Private",
+				// ... add other private include paths required here ...
+            }
+			);
+			
+		
+		PublicDependencyModuleNames.AddRange(
+			new string[]
+			{
+                "Core",
+				"UnrealEd",
+                "HSFLipSyncRuntime",
+				"Json", // For JSON handling
+				"JsonUtilities", // For JSON utilities
+				"DesktopPlatform", // Add this line
+				"AssetRegistry",
+                "EditorScriptingUtilities"
+            }
+			);
+			
+		
+		PrivateDependencyModuleNames.AddRange(
+			new string[]
+			{
+				"CoreUObject",
+				"Engine",
+				"Slate",
+				"SlateCore",
+				"InputCore",
+				"UnrealEd",
+				"LevelEditor",
+				"EditorScriptingUtilities", // Add this
+				"EditorStyle",         // Editor styles and icons
+				// ... add private dependencies that you statically link with here ...	
+				"InputCore",
+                "UnrealEd",
+                "ToolMenus",
+                "EditorWidgets",         // For widgets like SObjectPropertyEntryBox
+				"PropertyEditor",        // Required for property-related widgets
+				"AssetRegistry"
+			}
+			);
+		
+		
+		DynamicallyLoadedModuleNames.AddRange(
+			new string[]
+			{
+				// ... add any modules that your module loads dynamically here ...
+			}
+			);
+	}
+}

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Private/HSFLipMapFactory.cpp
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Private/HSFLipMapFactory.cpp
@@ -1,0 +1,49 @@
+#include "HSFLipMapFactory.h"
+
+#include "AssetToolsModule.h"
+#include "AssetTypeCategories.h"
+#include "IAssetTools.h"
+
+#define LOCTEXT_NAMESPACE "UHSFLipMap_Factory"
+
+UHSFLipMapFactory::UHSFLipMapFactory() {
+    bCreateNew = true;           
+    bEditAfterNew = true;       
+	bEditorImport = true;
+    SupportedClass = UHSFLipMap::StaticClass();
+}
+
+UObject* UHSFLipMapFactory::FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) {
+    return NewObject<UHSFLipMap>(InParent, Class, Name, Flags);
+}
+
+FText UHSFLipMapFactory::GetDisplayName() const
+{
+	return LOCTEXT("DisplayName", "HSF Lip Map");
+}
+
+static bool bSoundFactorySuppressImportOverwriteDialog = false;
+
+uint32 UHSFLipMapFactory::GetMenuCategories() const
+{
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	return AssetTools.RegisterAdvancedAssetCategory("HappySadFace", LOCTEXT("AssetCategoryName", "HappySadFace"));
+}
+
+
+
+bool UHSFLipMapFactory::ShouldShowInNewMenu() const
+{
+	return true;
+}
+
+UObject* UHSFLipMapFactory::FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled)
+{
+	FString PackagePath = FPackageName::GetLongPackagePath(InParent->GetOutermost()->GetName());
+
+	UHSFLipMap* ImportedAsset = NewObject<UHSFLipMap>(InParent, Name, Flags);
+	FString FilePath = FPaths::GetPath(CurrentFilename);
+	FPaths::MakePathRelativeTo(FilePath, *FPaths::ProjectDir());
+	return ImportedAsset;
+}
+#undef  LOCTEXT_NAMESPACE

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Private/HSFLipSyncDataPackFactory.cpp
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Private/HSFLipSyncDataPackFactory.cpp
@@ -1,0 +1,47 @@
+#include "HSFLipSyncDataPackFactory.h"
+
+#include "AssetToolsModule.h"
+#include "AssetTypeCategories.h"
+#include "IAssetTools.h"
+
+#define LOCTEXT_NAMESPACE "UHSFLipSyncDataPack_Factory"
+
+UHSFLipSyncDataPackFactory::UHSFLipSyncDataPackFactory() {
+    bCreateNew = true;           
+    bEditAfterNew = true;        
+    bEditorImport = true;
+    SupportedClass = UHSFLipSyncDataPack::StaticClass();
+}
+
+UObject* UHSFLipSyncDataPackFactory::FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) {
+    return NewObject<UHSFLipSyncDataPack>(InParent, Class, Name, Flags);
+}
+
+FText UHSFLipSyncDataPackFactory::GetDisplayName() const
+{
+	return LOCTEXT("DisplayName", "HSF Lip Sync Data Pack");
+}
+
+uint32 UHSFLipSyncDataPackFactory::GetMenuCategories() const
+{
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	return AssetTools.RegisterAdvancedAssetCategory("HappySadFace", LOCTEXT("AssetCategoryName", "HappySadFace"));
+}
+
+
+
+bool UHSFLipSyncDataPackFactory::ShouldShowInNewMenu() const
+{
+	return true;
+}
+
+UObject* UHSFLipSyncDataPackFactory::FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled)
+{
+	FString PackagePath = FPackageName::GetLongPackagePath(InParent->GetOutermost()->GetName());
+
+	UHSFLipSyncDataPack* ImportedAsset = NewObject<UHSFLipSyncDataPack>(InParent, Name, Flags);
+	FString FilePath = FPaths::GetPath(CurrentFilename);
+	FPaths::MakePathRelativeTo(FilePath, *FPaths::ProjectDir());
+	return ImportedAsset;
+}
+#undef  LOCTEXT_NAMESPACE

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Private/HSFLipSyncEditor.cpp
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Private/HSFLipSyncEditor.cpp
@@ -1,0 +1,28 @@
+// Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
+
+#include "HSFLipSyncEditor.h"
+#include "HSFLipSyncEditorEdMode.h"
+#include "AssetToolsModule.h"
+#include "IAssetTools.h"
+
+#define LOCTEXT_NAMESPACE "FHSFLipSyncEditorModule"
+
+void FHSFLipSyncEditorModule::StartupModule()
+{
+	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
+	FEditorModeRegistry::Get().RegisterMode<FHSFLipSyncEditorEdMode>(FHSFLipSyncEditorEdMode::EM_HSFLipSyncEditorEdModeId, LOCTEXT("HSFLipSyncEditorEdModeName", "HSFLipSyncEditorEdMode"), FSlateIcon(), true);
+	
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	AssetTools.RegisterAssetTypeActions(MakeShared<FAssetTypeActions_HSFLipMap>());
+	AssetTools.RegisterAssetTypeActions(MakeShared<FAssetTypeActions_HSFLipSyncDataPack>());
+}
+
+void FHSFLipSyncEditorModule::ShutdownModule()
+{
+	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
+	// we call this function before unloading the module.
+	FEditorModeRegistry::Get().UnregisterMode(FHSFLipSyncEditorEdMode::EM_HSFLipSyncEditorEdModeId);
+}
+#undef LOCTEXT_NAMESPACE
+	
+IMPLEMENT_MODULE(FHSFLipSyncEditorModule, HSFLipSyncEditor)

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Private/HSFLipSyncEditorEdMode.cpp
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Private/HSFLipSyncEditorEdMode.cpp
@@ -1,0 +1,50 @@
+// Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
+
+#include "HSFLipSyncEditorEdMode.h"
+#include "HSFLipSyncEditorEdModeToolkit.h"
+#include "Toolkits/ToolkitManager.h"
+#include "EditorModeManager.h"
+
+const FEditorModeID FHSFLipSyncEditorEdMode::EM_HSFLipSyncEditorEdModeId = TEXT("EM_HSFLipSyncEditorEdMode");
+
+FHSFLipSyncEditorEdMode::FHSFLipSyncEditorEdMode()
+{
+
+}
+
+FHSFLipSyncEditorEdMode::~FHSFLipSyncEditorEdMode()
+{
+
+}
+
+void FHSFLipSyncEditorEdMode::Enter()
+{
+	FEdMode::Enter();
+
+	if (!Toolkit.IsValid() && UsesToolkits())
+	{
+		Toolkit = MakeShareable(new FHSFLipSyncEditorEdModeToolkit);
+		Toolkit->Init(Owner->GetToolkitHost());
+	}
+}
+
+void FHSFLipSyncEditorEdMode::Exit()
+{
+	if (Toolkit.IsValid())
+	{
+		FToolkitManager::Get().CloseToolkit(Toolkit.ToSharedRef());
+		Toolkit.Reset();
+	}
+
+	// Call base Exit method to ensure proper cleanup
+	FEdMode::Exit();
+}
+
+bool FHSFLipSyncEditorEdMode::UsesToolkits() const
+{
+	return true;
+}
+
+
+
+

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Private/HSFLipSyncEditorEdModeToolkit.cpp
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Private/HSFLipSyncEditorEdModeToolkit.cpp
@@ -1,0 +1,569 @@
+#include "HSFLipSyncEditorEdModeToolkit.h"
+#include "HSFLipSyncEditorEdMode.h"
+#include "Engine/Selection.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Text/STextBlock.h"
+#include "EditorModeManager.h"
+#include "JsonObjectConverter.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "HSFLipMapJSONStructures.h"
+#include "DesktopPlatformModule.h"
+#include <IDesktopPlatform.h>
+#include "Engine/Selection.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Text/STextBlock.h"
+#include "EditorModeManager.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonSerializer.h"
+#include "Dom/JsonObject.h"
+#include "UObject/Package.h"
+#include "UObject/SavePackage.h" // Include for FSavePackageArgs and Save package functionality
+#include "AssetRegistry/AssetRegistryModule.h"
+
+
+#define LOCTEXT_NAMESPACE "FHSFLipSyncEditorEdModeToolkit"
+
+FHSFLipSyncEditorEdModeToolkit::FHSFLipSyncEditorEdModeToolkit()
+{
+}
+
+void FHSFLipSyncEditorEdModeToolkit::Init(const TSharedPtr<IToolkitHost>& InitToolkitHost)
+{
+    struct Locals
+    {
+        // Open a file dialog for JSON using DesktopPlatformModule
+        static bool OpenJsonFileDialog(FString& OutFilePath)
+        {
+            IDesktopPlatform* DesktopPlatform = FDesktopPlatformModule::Get();
+            if (DesktopPlatform)
+            {
+                TArray<FString> OutFiles;
+                const void* ParentWindowHandle = FSlateApplication::Get().FindBestParentWindowHandleForDialogs(nullptr);
+
+                if (DesktopPlatform->OpenFileDialog(
+                    ParentWindowHandle,
+                    TEXT("Import HSFLipMap JSON"),
+                    TEXT(""),
+                    TEXT(""),
+                    TEXT("JSON Files (*.json)|*.json"),
+                    EFileDialogFlags::None,
+                    OutFiles))
+                {
+                    OutFilePath = OutFiles[0];
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        static void ReadKeyFrames(FHSFLipSyncDataKeyFrame& NewKeyFrame, TSharedPtr<FJsonObject> KeyFrameObject)
+        {
+            NewKeyFrame.Phoneme = FName(*KeyFrameObject->GetStringField(TEXT("Phoneme")));
+            NewKeyFrame.StartTime = KeyFrameObject->GetNumberField(TEXT("StartTime"));
+            NewKeyFrame.EndTime = KeyFrameObject->GetNumberField(TEXT("EndTime"));
+            NewKeyFrame.Center = KeyFrameObject->GetNumberField(TEXT("Center"));
+            NewKeyFrame.Power = KeyFrameObject->GetNumberField(TEXT("Power"));
+            TArray<TSharedPtr<FJsonValue>> ShapesArray = KeyFrameObject->GetArrayField(TEXT("Shapes"));
+
+            for (const auto& ShapesValue : ShapesArray)
+            {
+                TSharedPtr<FJsonObject> ShapesObject = ShapesValue->AsObject();
+                float ShapesVal = ShapesObject->GetNumberField(TEXT("Value"));
+                NewKeyFrame.Shapes.Add(FName(*ShapesObject->GetStringField(TEXT("Key"))), ShapesVal);
+            }
+        }
+        static void ReadEmotions(FHSFLipSyncDataEmotion NewEmotion, TSharedPtr<FJsonObject> JsonObject)
+        {
+            NewEmotion.StartTime = JsonObject->GetNumberField(TEXT("StartTime"));
+            NewEmotion.EndTime = JsonObject->GetNumberField(TEXT("EndTime"));
+            NewEmotion.Calm = JsonObject->GetIntegerField(TEXT("Calm"));
+            NewEmotion.Anger = JsonObject->GetIntegerField(TEXT("Anger"));
+            NewEmotion.Joy = JsonObject->GetIntegerField(TEXT("Joy"));
+            NewEmotion.Sorrow = JsonObject->GetIntegerField(TEXT("Sorrow"));
+            NewEmotion.ExcitementLevel = JsonObject->GetIntegerField(TEXT("ExcitementLevel"));
+        }
+        static void ReadAttributes(FHSFLipMapShape& NewShape, TSharedPtr<FJsonObject> JsonObject)
+        {
+            // Process Attributes
+            if (JsonObject->HasField(TEXT("Attributes")))
+            {
+                TArray<TSharedPtr<FJsonValue>> AttributesArray = JsonObject->GetArrayField(TEXT("Attributes"));
+                for (const auto& AttributeValue : AttributesArray)
+                {
+                    TSharedPtr<FJsonObject> AttributeObject = AttributeValue->AsObject();
+                    FHSFLipMapShapeAttribute NewAttribute;
+
+                    TSharedPtr<FJsonObject> AttributeElement = AttributeObject->GetObjectField(TEXT("Value"));
+                    if (AttributeElement->HasField(TEXT("Data")))
+                    {
+                        // Modify this block to map the Key to the correct AttributeType
+                        TArray<TSharedPtr<FJsonValue>> DataArray = AttributeElement->GetArrayField(TEXT("Data"));
+                        for (const auto& DataValue : DataArray)
+                        {
+                            TSharedPtr<FJsonObject> DataObject = DataValue->AsObject();
+
+                            // Get the Key to determine the AttributeType
+                            FString Key = DataObject->GetStringField(TEXT("Key"));
+
+                            // Define a variable for the attribute type
+                            EHSFLipMapShapeAttributeType AttributeType = EHSFLipMapShapeAttributeType::TranslateX; // Default
+
+                            ReadAttributeType(AttributeType, Key);
+
+                            // Now retrieve the associated value and add it to the attribute data
+                            float DataVal = DataObject->GetNumberField(TEXT("Value"));
+                            NewAttribute.Data.Add(AttributeType, DataVal);
+                        }
+
+                    }
+
+                    // Add the attribute to shape
+                    NewShape.Attributes.Add(FName(*AttributeObject->GetStringField(TEXT("Key"))), NewAttribute);
+                }
+            }
+        }
+
+        static void ReadAttributeType(EHSFLipMapShapeAttributeType& AttributeType, FString Key)
+        {
+            // Map the Key to the appropriate AttributeType
+            if (Key.Equals(TEXT("EHSFLipMapShapeAttributeType::TranslateX")))
+            {
+                AttributeType = EHSFLipMapShapeAttributeType::TranslateX;
+            }
+            else if (Key.Equals(TEXT("EHSFLipMapShapeAttributeType::TranslateY")))
+            {
+                AttributeType = EHSFLipMapShapeAttributeType::TranslateY;
+            }
+            else if (Key.Equals(TEXT("EHSFLipMapShapeAttributeType::TranslateZ")))
+            {
+                AttributeType = EHSFLipMapShapeAttributeType::TranslateZ;
+            }
+            else if (Key.Equals(TEXT("EHSFLipMapShapeAttributeType::RotateX")))
+            {
+                AttributeType = EHSFLipMapShapeAttributeType::RotateX;
+            }
+            else if (Key.Equals(TEXT("EHSFLipMapShapeAttributeType::RotateY")))
+            {
+                AttributeType = EHSFLipMapShapeAttributeType::RotateY;
+            }
+            else if (Key.Equals(TEXT("EHSFLipMapShapeAttributeType::RotateZ")))
+            {
+                AttributeType = EHSFLipMapShapeAttributeType::RotateZ;
+            }
+            else if (Key.Equals(TEXT("EHSFLipMapShapeAttributeType::ScaleX")))
+            {
+                AttributeType = EHSFLipMapShapeAttributeType::ScaleX;
+            }
+            else if (Key.Equals(TEXT("EHSFLipMapShapeAttributeType::ScaleY")))
+            {
+                AttributeType = EHSFLipMapShapeAttributeType::ScaleY;
+            }
+            else if (Key.Equals(TEXT("EHSFLipMapShapeAttributeType::ScaleZ")))
+            {
+                AttributeType = EHSFLipMapShapeAttributeType::ScaleZ;
+            }
+            else
+            {
+                // Log a warning if the Key doesn't match any known type
+                UE_LOG(LogTemp, Warning, TEXT("Unknown attribute key: %s"), *Key);
+            }
+        }
+
+        static void ReadAudioData(FHSFLipMapShape& NewShape, TSharedPtr<FJsonObject> JsonObject)
+        {
+            if (JsonObject->HasField(TEXT("AudioMin")))
+                NewShape.AudioMin = JsonObject->GetNumberField(TEXT("AudioMin"));
+            if (JsonObject->HasField(TEXT("AudioMax")))
+                NewShape.AudioMax = JsonObject->GetNumberField(TEXT("AudioMax"));
+            if (JsonObject->HasField(TEXT("AudioPower")))
+                NewShape.AudioPower = JsonObject->GetNumberField(TEXT("AudioPower"));
+            if (JsonObject->HasField(TEXT("bBlend")))
+                NewShape.bBlend = JsonObject->GetBoolField(TEXT("bBlend"));
+            if (JsonObject->HasField(TEXT("BlendIn")))
+                NewShape.BlendIn = JsonObject->GetNumberField(TEXT("BlendIn"));
+            if (JsonObject->HasField(TEXT("BlendOut")))
+                NewShape.BlendOut = JsonObject->GetNumberField(TEXT("BlendOut"));
+            if (JsonObject->HasField(TEXT("bRandomize")))
+                NewShape.bRandomize = JsonObject->GetBoolField(TEXT("bRandomize"));
+            if (JsonObject->HasField(TEXT("RandomMin")))
+                NewShape.RandomMin = JsonObject->GetNumberField(TEXT("RandomMin"));
+            if (JsonObject->HasField(TEXT("RandomMax")))
+                NewShape.RandomMax = JsonObject->GetNumberField(TEXT("RandomMax"));
+        }
+        // Parse the JSON array from a file path
+        static bool ParseJsonArrayFromFile(const FString& FilePath, TArray<TSharedPtr<FJsonObject>>& JsonArray)
+        {
+            FString JsonString;
+            if (FFileHelper::LoadFileToString(JsonString, *FilePath))
+            {
+                if (JsonString.IsEmpty())
+                {
+                    UE_LOG(LogTemp, Error, TEXT("Failed to load JSON file: The content is empty."));
+                    return false;
+                }
+
+                // Try to deserialize the JSON array
+                TSharedRef<TJsonReader<TCHAR>> JsonReader = TJsonReaderFactory<TCHAR>::Create(JsonString);
+                TArray<TSharedPtr<FJsonValue>> JsonValueArray;
+                if (FJsonSerializer::Deserialize(JsonReader, JsonValueArray))
+                {
+                    for (const TSharedPtr<FJsonValue>& Value : JsonValueArray)
+                    {
+                        if (Value->Type == EJson::Object)
+                        {
+                            JsonArray.Add(Value->AsObject());
+                        }
+                    }
+                    UE_LOG(LogTemp, Log, TEXT("JSON array deserialized successfully."));
+                    return true;
+                }
+                else
+                {
+                    // Log the error if deserialization fails
+                    UE_LOG(LogTemp, Error, TEXT("Failed to deserialize JSON array."));
+                }
+            }
+            else
+            {
+                UE_LOG(LogTemp, Error, TEXT("Failed to load JSON file from path: %s"), *FilePath);
+            }
+
+            return false;
+        }
+
+        // Button handler to create the asset from parsed JSON using the factory
+        static FReply OnCreateHSFMapButtonClicked()
+        {
+            // Open the JSON file dialog
+            FString FilePath;
+            if (!OpenJsonFileDialog(FilePath))
+            {
+                return FReply::Handled();
+            }
+
+            TArray<TSharedPtr<FJsonObject>> ParsedJsonArray;
+            if (ParseJsonArrayFromFile(FilePath, ParsedJsonArray))
+            {
+                // Process each HSFLipMap
+                for (const TSharedPtr<FJsonObject>& JsonObject : ParsedJsonArray)
+                {
+                    FString AssetName = JsonObject->GetStringField(TEXT("Name"));
+                    FString PackagePath = TEXT("/Game/LipSync/LipMap/") / AssetName ;
+                    FString AssetPath = TEXT("/Game/LipSync/LipMap/");
+
+                    UPackage* NewPackage = CreatePackage(*PackagePath);
+
+                    // Use the factory to create the asset
+                    UHSFLipMapFactory* Factory = NewObject<UHSFLipMapFactory>();
+                    UHSFLipMap* NewAsset = Cast<UHSFLipMap>(Factory->FactoryCreateNew(UHSFLipMap::StaticClass(), NewPackage, FName(*AssetName), RF_Standalone | RF_Public, nullptr, GWarn));
+
+                    // Populate the asset with data from JSON
+                    TSharedPtr<FJsonObject> Properties = JsonObject->GetObjectField(TEXT("Properties"));
+                    NewAsset->Version = FName(*Properties->GetStringField(TEXT("version")));
+
+                    // Process Shapes
+                    if (Properties->HasField(TEXT("Shapes")))
+                    {
+                        TArray<TSharedPtr<FJsonValue>> ShapesArray = Properties->GetArrayField(TEXT("Shapes"));
+                        for (const auto& ShapeValue : ShapesArray)
+                        {
+                            TSharedPtr<FJsonObject> ShapeObject = ShapeValue->AsObject();
+
+
+                            TSharedPtr<FJsonObject> ShapeElement = ShapeObject->GetObjectField(TEXT("Value"));
+
+                            FHSFLipMapShape NewShape;
+                            ReadAttributes(NewShape, ShapeElement);
+                            ReadAudioData(NewShape, ShapeElement);
+
+                            // Add the shape to the map in the asset
+                            NewAsset->Shapes.Add(FName(*ShapeObject->GetStringField(TEXT("Key"))), NewShape);
+                        }
+                    }
+
+                    // Process Shapes
+                    if (Properties->HasField(TEXT("DefaultShape")))
+                    {
+                        TSharedPtr<FJsonObject> DefaultShapeObject = Properties->GetObjectField(TEXT("DefaultShape"));
+                        FHSFLipMapShape NewShape;
+                        ReadAttributes(NewShape, DefaultShapeObject);
+                        ReadAudioData(NewShape, DefaultShapeObject);
+
+                        // Add the shape to the map in the asset
+                        NewAsset->DefaultShape = NewShape;
+                    }
+
+                    // Process Shapes
+                    if (Properties->HasField(TEXT("MaxDifferenceShape")))
+                    {
+                        TSharedPtr<FJsonObject> MaxDifferenceShape = Properties->GetObjectField(TEXT("MaxDifferenceShape"));
+                        FHSFLipMapShape NewShape;
+                        ReadAttributes(NewShape, MaxDifferenceShape);
+                        ReadAudioData(NewShape, MaxDifferenceShape);
+
+                        // Add the shape to the map in the asset
+                        NewAsset->MaxDifferenceShape = NewShape;
+                    }
+
+                    NewAsset->MarkPackageDirty();
+                    NewPackage->SetDirtyFlag(true);
+
+
+                    FAssetRegistryModule::AssetCreated(NewAsset);	
+
+                    FString FilePathDest = FString::Printf(TEXT("%s%s%s"), *AssetPath, *FString(*AssetName), *FPackageName::GetAssetPackageExtension());
+                    //bool bSuccess = UPackage::SavePackage(NewPackage, NewAsset, EObjectFlags::RF_Public | EObjectFlags::RF_Standalone, *FilePathDest);
+
+                    //UE_LOG(LogTemp, Warning, TEXT("Saved Package: %s"), bSuccess ? TEXT("True") : TEXT("False"));
+                }
+            }
+
+            return FReply::Handled();
+        }static FReply OnCreateHSFPackButtonClicked()
+        {
+            // Open the JSON file dialog
+            FString FilePath;
+            if (!OpenJsonFileDialog(FilePath))
+            {
+                return FReply::Handled();
+            }
+
+            TArray<TSharedPtr<FJsonObject>> ParsedJsonArray;
+            if (ParseJsonArrayFromFile(FilePath, ParsedJsonArray))
+            {
+                // Process each HSFLipMap
+                for (const TSharedPtr<FJsonObject>& JsonObject : ParsedJsonArray)
+                {
+                    FString AssetName = JsonObject->GetStringField(TEXT("Name"));
+                    FString PackagePath = TEXT("/Game/LipSync/Lsd/") / AssetName;
+                    FString AssetPath = TEXT("/Game/LipSync/Lsd/");
+
+                    UPackage* NewPackage = CreatePackage(*PackagePath);
+
+                    // Use the factory to create the asset
+                    UHSFLipSyncDataPackFactory* Factory = NewObject<UHSFLipSyncDataPackFactory>();
+                    UHSFLipSyncDataPack* NewAsset = Cast<UHSFLipSyncDataPack>(Factory->FactoryCreateNew(UHSFLipSyncDataPack::StaticClass(), NewPackage, FName(*AssetName), RF_Standalone | RF_Public, nullptr, GWarn));
+
+                    // Populate the asset with data from JSON
+                    TSharedPtr<FJsonObject> Properties = JsonObject->GetObjectField(TEXT("Properties"));
+
+                    // Process Shapes
+                    if (Properties->HasField(TEXT("Data")))
+                    {
+                        TArray<TSharedPtr<FJsonValue>> DataArray = Properties->GetArrayField(TEXT("Data"));
+                        for (const auto& DataValue : DataArray)
+                        {
+                            TSharedPtr<FJsonObject> DataObject = DataValue->AsObject();
+                            TSharedPtr<FJsonObject> DataElement = DataObject->GetObjectField(TEXT("Value"));
+                            FHSFLipSyncData NewData;
+                            
+                            //Read File Info
+                            if (DataElement->HasField(TEXT("Info")))
+                            {
+                                FHSFLipSyncDataInfo NewDataInfo;
+                                TSharedPtr<FJsonObject> InfoObject = DataElement->GetObjectField(TEXT("Info"));
+                                NewDataInfo.Version = FName(*InfoObject->GetStringField(TEXT("version")));
+                                NewDataInfo.AudioLength = InfoObject->GetNumberField(TEXT("AudioLength"));
+                                NewDataInfo.AvgAudioPower = InfoObject->GetNumberField(TEXT("AvgAudioPower"));
+                                NewDataInfo.MaxAudioPower = InfoObject->GetNumberField(TEXT("MaxAudioPower"));
+                                TArray<TSharedPtr<FJsonValue>> KeyOrderArray = InfoObject->GetArrayField(TEXT("KeyOrder"));
+
+                                for (const auto& KeyOrderValue : KeyOrderArray)
+                                    NewDataInfo.KeyOrder.Add(FName(KeyOrderValue->AsString()));
+
+                                NewData.Info = NewDataInfo;
+                            }
+                            //Read KeyFrame Data
+                            if (DataElement->HasField(TEXT("KeyFrames")))
+                            {
+                                TArray<FHSFLipSyncDataKeyFrame> NewKeyFrameData;
+                                TArray<TSharedPtr<FJsonValue>> KeyFrameArray = DataElement->GetArrayField(TEXT("KeyFrames"));
+
+                                for (const auto& KeyFrameValue : KeyFrameArray)
+                                {
+                                    FHSFLipSyncDataKeyFrame NewKeyFrame;
+                                    TSharedPtr<FJsonObject> KeyFrameObject = KeyFrameValue->AsObject();
+
+                                    ReadKeyFrames(NewKeyFrame, KeyFrameObject);
+
+                                    NewKeyFrameData.Add(NewKeyFrame);
+                                }
+
+
+                                NewData.KeyFrames = NewKeyFrameData;
+                            }
+                            //Read KeyFrame Data
+                            if (DataElement->HasField(TEXT("OverrideKeyFrames")))
+                            {
+                                TArray<FHSFLipSyncDataKeyFrame> NewKeyFrameData;
+                                TArray<TSharedPtr<FJsonValue>> KeyFrameArray = DataElement->GetArrayField(TEXT("OverrideKeyFrames"));
+
+                                for (const auto& KeyFrameValue : KeyFrameArray)
+                                {
+                                    FHSFLipSyncDataKeyFrame NewKeyFrame;
+                                    TSharedPtr<FJsonObject> KeyFrameObject = KeyFrameValue->AsObject();
+
+                                    ReadKeyFrames(NewKeyFrame, KeyFrameObject);
+
+                                    NewKeyFrameData.Add(NewKeyFrame);
+                                }
+
+
+                                NewData.OverrideKeyFrames = NewKeyFrameData;
+                            }
+                            //Read Emotions Data
+                            if (DataElement->HasField(TEXT("Emotions")))
+                            {
+                                TArray<FHSFLipSyncDataEmotion> NewEmotionsData;
+                                TArray<TSharedPtr<FJsonValue>> EmotionArray = DataElement->GetArrayField(TEXT("Emotions"));
+
+                                for (const auto& EmotionValue : EmotionArray)
+                                {
+                                    FHSFLipSyncDataEmotion NewEmotion;
+                                    TSharedPtr<FJsonObject> EmotionObject = EmotionValue->AsObject();
+
+                                    ReadEmotions(NewEmotion, EmotionObject);
+
+                                    NewEmotionsData.Add(NewEmotion);
+                                }
+
+
+                                NewData.Emotions = NewEmotionsData;
+                            }
+                            //Read JpOverrideEmotions Data --- Remake only
+                            /*if (DataElement->HasField(TEXT("JpOverrideEmotions")))
+                            {
+                                TArray<FHSFLipSyncDataEmotion> NewEmotionsData;
+                                TArray<TSharedPtr<FJsonValue>> EmotionArray = DataElement->GetArrayField(TEXT("JpOverrideEmotions"));
+
+                                for (const auto& EmotionValue : EmotionArray)
+                                {
+                                    FHSFLipSyncDataEmotion NewEmotion;
+                                    TSharedPtr<FJsonObject> EmotionObject = EmotionValue->AsObject();
+
+                                    ReadEmotions(NewEmotion, EmotionObject);
+
+                                    NewEmotionsData.Add(NewEmotion);
+                                }
+
+
+                                NewData.JpOverrideEmotions = NewEmotionsData;
+                            }*/
+                            //Read JpOverrideEmotions Data
+                            if (DataElement->HasField(TEXT("OverrideEmotions")))
+                            {
+                                TArray<FHSFLipSyncDataEmotion> NewEmotionsData;
+                                TArray<TSharedPtr<FJsonValue>> EmotionArray = DataElement->GetArrayField(TEXT("OverrideEmotions"));
+
+                                for (const auto& EmotionValue : EmotionArray)
+                                {
+                                    FHSFLipSyncDataEmotion NewEmotion;
+                                    TSharedPtr<FJsonObject> EmotionObject = EmotionValue->AsObject();
+
+                                    ReadEmotions(NewEmotion, EmotionObject);
+
+                                    NewEmotionsData.Add(NewEmotion);
+                                }
+
+
+                                NewData.OverrideEmotions = NewEmotionsData;
+                            }
+                            // Add the shape to the map in the asset
+                            NewAsset->Data.Add(FName(*DataObject->GetStringField(TEXT("Key"))), NewData);
+                        }
+                    }
+
+
+                    NewAsset->MarkPackageDirty();
+                    NewPackage->SetDirtyFlag(true);
+
+
+                    FAssetRegistryModule::AssetCreated(NewAsset);
+
+                    FString FilePathDest = FString::Printf(TEXT("%s%s%s"), *AssetPath, *FString(*AssetName), *FPackageName::GetAssetPackageExtension());
+                    //bool bSuccess = UPackage::SavePackage(NewPackage, NewAsset, EObjectFlags::RF_Public | EObjectFlags::RF_Standalone, *FilePathDest);
+
+                    //UE_LOG(LogTemp, Warning, TEXT("Saved Package: %s"), bSuccess ? TEXT("True") : TEXT("False"));
+                }
+            }
+
+            return FReply::Handled();
+        }
+
+        // Utility function to create the button
+        static TSharedRef<SWidget> CreateHSFMapAssetButton()
+        {
+            return SNew(SButton)
+                .Text(LOCTEXT("CreateAssetButton", "Create HSF Map from JSON"))
+                .OnClicked_Static(&Locals::OnCreateHSFMapButtonClicked);
+        }
+        static TSharedRef<SWidget> CreateHSFPackAssetButton()
+        {
+            return SNew(SButton)
+                .Text(LOCTEXT("CreateAssetButton", "Create HSF Pack from JSON"))
+                .OnClicked_Static(&Locals::OnCreateHSFPackButtonClicked);
+        }
+    };
+
+    const float Factor = 256.0f;
+
+    SAssignNew(ToolkitWidget, SBorder)
+        .HAlign(HAlign_Center)
+        .Padding(25)
+        [
+            SNew(SVerticalBox)
+                + SVerticalBox::Slot()
+                .AutoHeight()
+                .HAlign(HAlign_Center)
+                .Padding(50)
+                [
+                    SNew(STextBlock)
+                        .AutoWrapText(true)
+                        .Text(LOCTEXT("HelperLabel", "Select a JSON file to create the HSF Map asset"))
+                ]
+                + SVerticalBox::Slot()
+                .HAlign(HAlign_Center)
+                .AutoHeight()
+                [
+                    Locals::CreateHSFMapAssetButton()
+                ]
+
+                + SVerticalBox::Slot()
+                .AutoHeight()
+                .HAlign(HAlign_Center)
+                .Padding(50)
+                [
+                    SNew(STextBlock)
+                        .AutoWrapText(true)
+                        .Text(LOCTEXT("HelperLabel", "Select a JSON file to create HSF Data Pack the asset"))
+                ]
+                + SVerticalBox::Slot()
+                .HAlign(HAlign_Center)
+                .AutoHeight()
+                [
+                    Locals::CreateHSFPackAssetButton()
+                ]
+
+        ];
+
+    FModeToolkit::Init(InitToolkitHost);
+}
+
+FName FHSFLipSyncEditorEdModeToolkit::GetToolkitFName() const
+{
+    return FName("HSF LipSync");
+}
+
+FText FHSFLipSyncEditorEdModeToolkit::GetBaseToolkitName() const
+{
+    return NSLOCTEXT("HSFLipSyncEditorEdModeToolkit", "DisplayName", "HSF LipSync Tool");
+}
+
+class FEdMode* FHSFLipSyncEditorEdModeToolkit::GetEditorMode() const
+{
+    return GLevelEditorModeTools().GetActiveMode(FHSFLipSyncEditorEdMode::EM_HSFLipSyncEditorEdModeId);
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipMapFactory.h
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipMapFactory.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Factories/Factory.h"
+#include "HSFLipMap.h"
+
+#include "HSFLipMapFactory.generated.h"
+
+UCLASS()
+class HSFLIPSYNCEDITOR_API UHSFLipMapFactory : public UFactory {
+    GENERATED_BODY()
+
+public:
+    UHSFLipMapFactory();
+
+    virtual uint32 GetMenuCategories() const override;
+    virtual FText GetDisplayName() const override;
+    virtual UObject* FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) override;
+    virtual bool ShouldShowInNewMenu() const override;
+    virtual UObject* FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled) override;
+};
+
+

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipMapJSONStructures.h
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipMapJSONStructures.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "EHSFLipMapShapeAttributeType.h"
+#include "HSFLipMapShapeAttribute.h"
+#include "HSFLipMapShape.h"
+
+#include "HSFLipMapJSONStructures.generated.h"
+
+// JSON-compatible structure for attributes
+USTRUCT()
+struct FHSFLipMapShapeAttributeJSON {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    FName Key;
+
+    UPROPERTY()
+    float Value;
+};
+
+// JSON-compatible structure for shapes
+USTRUCT()
+struct FHSFLipMapShapeJSON {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    FName Key;
+
+    UPROPERTY()
+    TArray<FHSFLipMapShapeAttributeJSON> Attributes;
+};
+
+// Root JSON structure
+USTRUCT()
+struct FHSFLipMapJSON {
+    GENERATED_BODY()
+
+    UPROPERTY()
+    FString Type;
+
+    UPROPERTY()
+    FString Class;
+
+    UPROPERTY()
+    FName Name;
+
+    UPROPERTY()
+    FString version;
+
+    UPROPERTY()
+    TArray<FHSFLipMapShapeJSON> Shapes;
+};

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipSyncDataPackFactory.h
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipSyncDataPackFactory.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Factories/Factory.h"
+#include "HSFLipSyncDataPack.h"
+
+#include "HSFLipSyncDataPackFactory.generated.h"
+
+UCLASS()
+class HSFLIPSYNCEDITOR_API UHSFLipSyncDataPackFactory : public UFactory {
+    GENERATED_BODY()
+
+public:
+    UHSFLipSyncDataPackFactory();
+  
+    virtual uint32 GetMenuCategories() const override;
+    virtual FText GetDisplayName() const override;
+    virtual UObject* FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) override;
+    virtual bool ShouldShowInNewMenu() const override;
+    virtual UObject* FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled) override;
+};
+
+

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipSyncEditor.h
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipSyncEditor.h
@@ -1,0 +1,35 @@
+// Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
+#include "AssetTypeActions_Base.h"
+#include "HSFLipMapFactory.h"
+#include "HSFLipSyncDataPackFactory.h"
+
+class FHSFLipSyncEditorModule : public IModuleInterface
+{
+public:
+
+	/** IModuleInterface implementation */
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};
+
+class FAssetTypeActions_HSFLipMap : public FAssetTypeActions_Base {
+public:
+    virtual FText GetName() const override { return NSLOCTEXT("AssetTypeActions", "AssetTypeActions_HSFLipMap", "HSF Lip Map"); }
+    virtual FColor GetTypeColor() const override { return FColor::Red; }
+    virtual UClass* GetSupportedClass() const override { return UHSFLipMap::StaticClass(); }
+    virtual uint32 GetCategories() override { return EAssetTypeCategories::Misc; }
+};
+
+
+class FAssetTypeActions_HSFLipSyncDataPack : public FAssetTypeActions_Base {
+public:
+    virtual FText GetName() const override { return NSLOCTEXT("AssetTypeActions", "AssetTypeActions_HSFLipSyncDataPack", "HSF Lip Sync Data Pack"); }
+    virtual FColor GetTypeColor() const override { return FColor::Red; }
+    virtual UClass* GetSupportedClass() const override { return UHSFLipSyncDataPack::StaticClass(); }
+    virtual uint32 GetCategories() override { return EAssetTypeCategories::Misc; }
+};

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipSyncEditorEdMode.h
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipSyncEditorEdMode.h
@@ -1,0 +1,25 @@
+// Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "EdMode.h"
+
+class FHSFLipSyncEditorEdMode : public FEdMode
+{
+public:
+	const static FEditorModeID EM_HSFLipSyncEditorEdModeId;
+public:
+	FHSFLipSyncEditorEdMode();
+	virtual ~FHSFLipSyncEditorEdMode();
+
+	// FEdMode interface
+	virtual void Enter() override;
+	virtual void Exit() override;
+	//virtual void Tick(FEditorViewportClient* ViewportClient, float DeltaTime) override;
+	//virtual void Render(const FSceneView* View, FViewport* Viewport, FPrimitiveDrawInterface* PDI) override;
+	//virtual void ActorSelectionChangeNotify() override;
+	bool UsesToolkits() const override;
+
+	// End of FEdMode interface
+};

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipSyncEditorEdModeToolkit.h
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncEditor/Public/HSFLipSyncEditorEdModeToolkit.h
@@ -1,0 +1,28 @@
+// Copyright 1998-2017 Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Toolkits/BaseToolkit.h"
+#include "HSFLipMapFactory.h"
+#include "HSFLipSyncDataPackFactory.h"
+
+class FHSFLipSyncEditorEdModeToolkit : public FModeToolkit
+{
+public:
+
+	FHSFLipSyncEditorEdModeToolkit();
+	
+	/** FModeToolkit interface */
+	virtual void Init(const TSharedPtr<IToolkitHost>& InitToolkitHost) override;
+
+	/** IToolkit interface */
+	virtual FName GetToolkitFName() const override;
+	virtual FText GetBaseToolkitName() const override;
+	virtual class FEdMode* GetEditorMode() const override;
+	virtual TSharedPtr<class SWidget> GetInlineContent() const override { return ToolkitWidget; }
+
+private:
+
+	TSharedPtr<SWidget> ToolkitWidget;
+};

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncRuntime/Private/AnimNode_HSFLipSync.cpp
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncRuntime/Private/AnimNode_HSFLipSync.cpp
@@ -3,3 +3,15 @@
 FAnimNode_HSFLipSync::FAnimNode_HSFLipSync() {
 }
 
+void FAnimNode_HSFLipSync::Initialize_AnyThread(const FAnimationInitializeContext &Context)
+{
+    FAnimNode_Base::Initialize_AnyThread(Context);
+}
+
+void FAnimNode_HSFLipSync::Update_AnyThread(const FAnimationUpdateContext &Context)
+{
+}
+
+void FAnimNode_HSFLipSync::Evaluate_AnyThread(FPoseContext &Output)
+{
+}

--- a/Plugins/HappySadFaceLipSync/Source/HSFLipSyncRuntime/Public/AnimNode_HSFLipSync.h
+++ b/Plugins/HappySadFaceLipSync/Source/HSFLipSyncRuntime/Public/AnimNode_HSFLipSync.h
@@ -21,5 +21,10 @@ public:
     FHSFLipMapShape DummyShape;
     
     FAnimNode_HSFLipSync();
+
+    // Override required functions
+    virtual void Initialize_AnyThread(const FAnimationInitializeContext &Context) override;
+    virtual void Update_AnyThread(const FAnimationUpdateContext &Context) override;
+    virtual void Evaluate_AnyThread(FPoseContext &Output) override;
 };
 

--- a/Source/ENDEditor/Private/ENDEditorModule.cpp
+++ b/Source/ENDEditor/Private/ENDEditorModule.cpp
@@ -3,6 +3,11 @@
 #include "AssetToolsModule.h"
 #include "AssetTypeActions_EffectAppendixMesh.h"
 #include "AssetTypeActions_EndEmissiveColorSettings.h"
+#include "AssetTypeActions_EndCinemaSequence.h"
+#include "AssetTypeActions_EndCameraSequence.h"
+#include "AssetTypeActions_ShaderResourceBuffer.h"
+#include "AssetTypeActions_EndAssetPack.h"
+#include "AssetTypeActions_EndAnimSet.h"
 
 void FENDEditorModule::StartupModule()
 {
@@ -13,8 +18,18 @@ void FENDEditorModule::StartupModule()
 	EAssetTypeCategories::Type CustomAssetCategory = AssetTools.RegisterAdvancedAssetCategory(FName("SQEX"), FText::FromString("SQEX"));
 	AssetAction = new FAssetTypeActions_EndEmissiveColorSettings(CustomAssetCategory);
 	AssetAction2 = new FAssetTypeActions_EffectAppendixMesh(CustomAssetCategory);
+	AssetAction3 = new FAssetTypeActions_EndCameraSequence(CustomAssetCategory);
+	AssetAction4 = new FAssetTypeActions_EndCinemaSequence(CustomAssetCategory);
+	AssetAction5 = new FAssetTypeActions_EndAnimSet(CustomAssetCategory);
+	AssetAction6 = new FAssetTypeActions_EndAssetPack(CustomAssetCategory);
+	AssetAction7 = new FAssetTypeActions_ShaderResourceBuffer(CustomAssetCategory);
 	AssetTools.RegisterAssetTypeActions(MakeShareable(AssetAction));
 	AssetTools.RegisterAssetTypeActions(MakeShareable(AssetAction2));
+	AssetTools.RegisterAssetTypeActions(MakeShareable(AssetAction3));
+	AssetTools.RegisterAssetTypeActions(MakeShareable(AssetAction4));
+	AssetTools.RegisterAssetTypeActions(MakeShareable(AssetAction5));
+	AssetTools.RegisterAssetTypeActions(MakeShareable(AssetAction6));
+	AssetTools.RegisterAssetTypeActions(MakeShareable(AssetAction7));
 }
 
 void FENDEditorModule::ShutdownModule()
@@ -25,6 +40,11 @@ void FENDEditorModule::ShutdownModule()
 		IAssetTools& AssetTools = AssetToolsModule.Get();
 		AssetTools.UnregisterAssetTypeActions(AssetAction->AsShared());
 		AssetTools.UnregisterAssetTypeActions(AssetAction2->AsShared());
+		AssetTools.UnregisterAssetTypeActions(AssetAction3->AsShared());
+		AssetTools.UnregisterAssetTypeActions(AssetAction4->AsShared());
+		AssetTools.UnregisterAssetTypeActions(AssetAction5->AsShared());
+		AssetTools.UnregisterAssetTypeActions(AssetAction6->AsShared());
+		AssetTools.UnregisterAssetTypeActions(AssetAction7->AsShared());
 	}
 }
 	

--- a/Source/ENDEditor/Private/EndAnimSet_Factory.cpp
+++ b/Source/ENDEditor/Private/EndAnimSet_Factory.cpp
@@ -1,0 +1,52 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "EndAnimSet_Factory.h"
+
+#include "AssetToolsModule.h"
+#include "AssetTypeCategories.h"
+#include "IAssetTools.h"
+#include "EndAnimSet.h"
+
+#define LOCTEXT_NAMESPACE "UEndAnimSet_Factory"
+
+UEndAnimSet_Factory::UEndAnimSet_Factory()
+{
+	Formats.Add(TEXT("xml;EndAnimSet"));
+	bCreateNew = true;
+	bEditAfterNew = true;
+	bEditorImport = true;
+	SupportedClass = UEndAnimSet::StaticClass();
+}
+
+FText UEndAnimSet_Factory::GetDisplayName() const
+{
+	return LOCTEXT("DisplayName", "End Anim Set");
+}
+
+uint32 UEndAnimSet_Factory::GetMenuCategories() const
+{
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	return AssetTools.RegisterAdvancedAssetCategory("SQEX", LOCTEXT("AssetCategoryName", "SQEX"));
+}
+
+UObject * UEndAnimSet_Factory::FactoryCreateNew(UClass * InClass, UObject * InParent, FName InName, EObjectFlags flags, UObject * Cntext, FFeedbackContext * Warn)
+{
+	return NewObject<UEndAnimSet>(InParent, InClass, InName, flags);
+}
+
+bool UEndAnimSet_Factory::ShouldShowInNewMenu() const
+{
+	return true;
+}
+
+UObject* UEndAnimSet_Factory::FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled)
+{
+	FString PackagePath = FPackageName::GetLongPackagePath(InParent->GetOutermost()->GetName());
+
+	UEndAnimSet* ImportedAsset = NewObject<UEndAnimSet>(InParent, Name, Flags);
+	FString FilePath = FPaths::GetPath(CurrentFilename);
+	FPaths::MakePathRelativeTo(FilePath, *FPaths::ProjectDir());
+	return ImportedAsset;
+}
+
+#undef  LOCTEXT_NAMESPACE

--- a/Source/ENDEditor/Private/EndAssetPack_Factory.cpp
+++ b/Source/ENDEditor/Private/EndAssetPack_Factory.cpp
@@ -1,0 +1,52 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "EndAssetPack_Factory.h"
+
+#include "AssetToolsModule.h"
+#include "AssetTypeCategories.h"
+#include "IAssetTools.h"
+#include "EndAssetPack.h"
+
+#define LOCTEXT_NAMESPACE "UEndAssetPack_Factory"
+
+UEndAssetPack_Factory::UEndAssetPack_Factory()
+{
+	Formats.Add(TEXT("xml;EndAssetPack"));
+	bCreateNew = true;
+	bEditAfterNew = true;
+	bEditorImport = true;
+	SupportedClass = UEndAssetPack::StaticClass();
+}
+
+FText UEndAssetPack_Factory::GetDisplayName() const
+{
+	return LOCTEXT("DisplayName", "End Asset Pack");
+}
+
+uint32 UEndAssetPack_Factory::GetMenuCategories() const
+{
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	return AssetTools.RegisterAdvancedAssetCategory("SQEX", LOCTEXT("AssetCategoryName", "SQEX"));
+}
+
+UObject * UEndAssetPack_Factory::FactoryCreateNew(UClass * InClass, UObject * InParent, FName InName, EObjectFlags flags, UObject * Cntext, FFeedbackContext * Warn)
+{
+	return NewObject<UEndAssetPack>(InParent, InClass, InName, flags);
+}
+
+bool UEndAssetPack_Factory::ShouldShowInNewMenu() const
+{
+	return true;
+}
+
+UObject* UEndAssetPack_Factory::FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled)
+{
+	FString PackagePath = FPackageName::GetLongPackagePath(InParent->GetOutermost()->GetName());
+
+	UEndAssetPack* ImportedAsset = NewObject<UEndAssetPack>(InParent, Name, Flags);
+	FString FilePath = FPaths::GetPath(CurrentFilename);
+	FPaths::MakePathRelativeTo(FilePath, *FPaths::ProjectDir());
+	return ImportedAsset;
+}
+
+#undef  LOCTEXT_NAMESPACE

--- a/Source/ENDEditor/Private/EndCameraSequence_Factory.cpp
+++ b/Source/ENDEditor/Private/EndCameraSequence_Factory.cpp
@@ -1,0 +1,52 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "EndCameraSequence_Factory.h"
+
+#include "AssetToolsModule.h"
+#include "AssetTypeCategories.h"
+#include "IAssetTools.h"
+#include "EndCameraSequence.h"
+
+#define LOCTEXT_NAMESPACE "UEndCameraSequence_Factory"
+
+UEndCameraSequence_Factory::UEndCameraSequence_Factory()
+{
+	Formats.Add(TEXT("xml;EndAssetPack"));
+	bCreateNew = true;
+	bEditAfterNew = true;
+	bEditorImport = true;
+	SupportedClass = UEndCameraSequence::StaticClass();
+}
+
+FText UEndCameraSequence_Factory::GetDisplayName() const
+{
+	return LOCTEXT("DisplayName", "End Camera Sequence");
+}
+
+uint32 UEndCameraSequence_Factory::GetMenuCategories() const
+{
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	return AssetTools.RegisterAdvancedAssetCategory("SQEX", LOCTEXT("AssetCategoryName", "SQEX"));
+}
+
+UObject * UEndCameraSequence_Factory::FactoryCreateNew(UClass * InClass, UObject * InParent, FName InName, EObjectFlags flags, UObject * Cntext, FFeedbackContext * Warn)
+{
+	return NewObject<UEndCameraSequence>(InParent, InClass, InName, flags);
+}
+
+bool UEndCameraSequence_Factory::ShouldShowInNewMenu() const
+{
+	return true;
+}
+
+UObject* UEndCameraSequence_Factory::FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled)
+{
+	FString PackagePath = FPackageName::GetLongPackagePath(InParent->GetOutermost()->GetName());
+
+	UEndCameraSequence* ImportedAsset = NewObject<UEndCameraSequence>(InParent, Name, Flags);
+	FString FilePath = FPaths::GetPath(CurrentFilename);
+	FPaths::MakePathRelativeTo(FilePath, *FPaths::ProjectDir());
+	return ImportedAsset;
+}
+
+#undef  LOCTEXT_NAMESPACE

--- a/Source/ENDEditor/Private/EndCinemaSequence_Factory.cpp
+++ b/Source/ENDEditor/Private/EndCinemaSequence_Factory.cpp
@@ -1,0 +1,52 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "EndCinemaSequence_Factory.h"
+
+#include "AssetToolsModule.h"
+#include "AssetTypeCategories.h"
+#include "IAssetTools.h"
+#include "EndCinemaSequence.h"
+
+#define LOCTEXT_NAMESPACE "UEndCinemaSequence_Factory"
+
+UEndCinemaSequence_Factory::UEndCinemaSequence_Factory()
+{
+	Formats.Add(TEXT("xml;EndAssetPack"));
+	bCreateNew = true;
+	bEditAfterNew = true;
+	bEditorImport = true;
+	SupportedClass = UEndCinemaSequence::StaticClass();
+}
+
+FText UEndCinemaSequence_Factory::GetDisplayName() const
+{
+	return LOCTEXT("DisplayName", "End Cinema Sequence");
+}
+
+uint32 UEndCinemaSequence_Factory::GetMenuCategories() const
+{
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	return AssetTools.RegisterAdvancedAssetCategory("SQEX", LOCTEXT("AssetCategoryName", "SQEX"));
+}
+
+UObject * UEndCinemaSequence_Factory::FactoryCreateNew(UClass * InClass, UObject * InParent, FName InName, EObjectFlags flags, UObject * Cntext, FFeedbackContext * Warn)
+{
+	return NewObject<UEndCinemaSequence>(InParent, InClass, InName, flags);
+}
+
+bool UEndCinemaSequence_Factory::ShouldShowInNewMenu() const
+{
+	return true;
+}
+
+UObject* UEndCinemaSequence_Factory::FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled)
+{
+	FString PackagePath = FPackageName::GetLongPackagePath(InParent->GetOutermost()->GetName());
+
+	UEndCinemaSequence* ImportedAsset = NewObject<UEndCinemaSequence>(InParent, Name, Flags);
+	FString FilePath = FPaths::GetPath(CurrentFilename);
+	FPaths::MakePathRelativeTo(FilePath, *FPaths::ProjectDir());
+	return ImportedAsset;
+}
+
+#undef  LOCTEXT_NAMESPACE

--- a/Source/ENDEditor/Private/ShaderResourceBuffer_Factory.cpp
+++ b/Source/ENDEditor/Private/ShaderResourceBuffer_Factory.cpp
@@ -1,0 +1,54 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "ShaderResourceBuffer_Factory.h"
+
+#include "AssetToolsModule.h"
+#include "AssetTypeCategories.h"
+#include "IAssetTools.h"
+#include "ShaderResourceBuffer.h"
+
+#define LOCTEXT_NAMESPACE "UShaderResourceBuffer_Factory"
+
+UShaderResourceBuffer_Factory::UShaderResourceBuffer_Factory()
+{
+	Formats.Add(TEXT("xml;ShaderResourceBuffer"));
+	bCreateNew = true;
+	bEditAfterNew = true;
+	bEditorImport = true;
+	SupportedClass = UShaderResourceBuffer::StaticClass();
+}
+
+FText UShaderResourceBuffer_Factory::GetDisplayName() const
+{
+	return LOCTEXT("DisplayName", "Shader Resource Buffer");
+}
+
+static bool bSoundFactorySuppressImportOverwriteDialog = false;
+
+uint32 UShaderResourceBuffer_Factory::GetMenuCategories() const
+{
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	return AssetTools.RegisterAdvancedAssetCategory("SQEX", LOCTEXT("AssetCategoryName", "SQEX"));
+}
+
+UObject * UShaderResourceBuffer_Factory::FactoryCreateNew(UClass * InClass, UObject * InParent, FName InName, EObjectFlags flags, UObject * Cntext, FFeedbackContext * Warn)
+{
+	return NewObject<UShaderResourceBuffer>(InParent, InClass, InName, flags);
+}
+
+bool UShaderResourceBuffer_Factory::ShouldShowInNewMenu() const
+{
+	return true;
+}
+
+UObject* UShaderResourceBuffer_Factory::FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled)
+{
+	FString PackagePath = FPackageName::GetLongPackagePath(InParent->GetOutermost()->GetName());
+
+	UShaderResourceBuffer* ImportedAsset = NewObject<UShaderResourceBuffer>(InParent, Name, Flags);
+	FString FilePath = FPaths::GetPath(CurrentFilename);
+	FPaths::MakePathRelativeTo(FilePath, *FPaths::ProjectDir());
+	return ImportedAsset;
+}
+
+#undef  LOCTEXT_NAMESPACE

--- a/Source/ENDEditor/Public/AssetTypeActions_EndAnimSet.h
+++ b/Source/ENDEditor/Public/AssetTypeActions_EndAnimSet.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AssetTypeCategories.h"
+#include "AssetTypeActions_Base.h"
+#include "EndAnimSet.h"
+
+class FAssetTypeActions_EndAnimSet : public FAssetTypeActions_Base
+{
+public:
+	FAssetTypeActions_EndAnimSet(EAssetTypeCategories::Type InAssetCategory)
+            : AssetCategory(InAssetCategory)
+        {}
+	// IAssetTypeActions Implementation
+	virtual FText GetName() const override { return NSLOCTEXT("AssetTypeActions", "FAssetTypeActions_EndAnimSet", "End Anim Set"); }
+	virtual FColor GetTypeColor() const override { return FColor::Magenta; }
+	virtual UClass* GetSupportedClass() const override { return UEndAnimSet::StaticClass(); }
+	virtual uint32 GetCategories() override { return AssetCategory; }
+    
+private:
+    EAssetTypeCategories::Type AssetCategory;
+};

--- a/Source/ENDEditor/Public/AssetTypeActions_EndAssetPack.h
+++ b/Source/ENDEditor/Public/AssetTypeActions_EndAssetPack.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AssetTypeCategories.h"
+#include "AssetTypeActions_Base.h"
+#include "EndAssetPack.h"
+
+class FAssetTypeActions_EndAssetPack : public FAssetTypeActions_Base
+{
+public:
+	FAssetTypeActions_EndAssetPack(EAssetTypeCategories::Type InAssetCategory)
+            : AssetCategory(InAssetCategory)
+        {}
+	// IAssetTypeActions Implementation
+	virtual FText GetName() const override { return NSLOCTEXT("AssetTypeActions", "AssetTypeActions_EndAssetPack", "End Asset Pack"); }
+	virtual FColor GetTypeColor() const override { return FColor::Magenta; }
+	virtual UClass* GetSupportedClass() const override { return UEndAssetPack::StaticClass(); }	
+	virtual uint32 GetCategories() override { return AssetCategory; }
+    
+private:
+    EAssetTypeCategories::Type AssetCategory;
+};

--- a/Source/ENDEditor/Public/AssetTypeActions_EndCameraSequence.h
+++ b/Source/ENDEditor/Public/AssetTypeActions_EndCameraSequence.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AssetTypeCategories.h"
+#include "AssetTypeActions_Base.h"
+#include "EndCameraSequence.h"
+
+class FAssetTypeActions_EndCameraSequence : public FAssetTypeActions_Base
+{
+public:
+    FAssetTypeActions_EndCameraSequence(EAssetTypeCategories::Type InAssetCategory)
+            : AssetCategory(InAssetCategory)
+        {}
+	// IAssetTypeActions Implementation
+	virtual FText GetName() const override { return NSLOCTEXT("AssetTypeActions", "AssetTypeActions_EndCameraSequence", "End Camera Sequence"); }
+	virtual FColor GetTypeColor() const override { return FColor::Magenta; }
+	virtual UClass* GetSupportedClass() const override { return UEndCameraSequence::StaticClass(); }
+	virtual uint32 GetCategories() override { return AssetCategory; }
+    
+private:
+    EAssetTypeCategories::Type AssetCategory;
+};

--- a/Source/ENDEditor/Public/AssetTypeActions_EndCinemaSequence.h
+++ b/Source/ENDEditor/Public/AssetTypeActions_EndCinemaSequence.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AssetTypeCategories.h"
+#include "AssetTypeActions_Base.h"
+#include "EndCinemaSequence.h"
+
+class FAssetTypeActions_EndCinemaSequence : public FAssetTypeActions_Base
+{
+public:
+    FAssetTypeActions_EndCinemaSequence(EAssetTypeCategories::Type InAssetCategory)
+            : AssetCategory(InAssetCategory)
+        {}
+	// IAssetTypeActions Implementation
+	virtual FText GetName() const override { return NSLOCTEXT("AssetTypeActions", "AssetTypeActions_EndCinemaSequence", "End Cinema Sequence"); }
+	virtual FColor GetTypeColor() const override { return FColor::Magenta; }
+	virtual UClass* GetSupportedClass() const override { return UEndCinemaSequence::StaticClass(); }
+	virtual uint32 GetCategories() override { return AssetCategory; }
+    
+private:
+    EAssetTypeCategories::Type AssetCategory;
+};

--- a/Source/ENDEditor/Public/AssetTypeActions_ShaderResourceBuffer.h
+++ b/Source/ENDEditor/Public/AssetTypeActions_ShaderResourceBuffer.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AssetTypeCategories.h"
+#include "AssetTypeActions_Base.h"
+#include "ShaderResourceBuffer.h"
+
+class FAssetTypeActions_ShaderResourceBuffer : public FAssetTypeActions_Base
+{
+public:
+	FAssetTypeActions_ShaderResourceBuffer(EAssetTypeCategories::Type InAssetCategory)
+            : AssetCategory(InAssetCategory)
+        {}
+	// IAssetTypeActions Implementation
+	virtual FText GetName() const override { return NSLOCTEXT("AssetTypeActions", "AssetTypeActions_ShaderResourceBuffer", "Shader Resource Buffer"); }
+	virtual FColor GetTypeColor() const override { return FColor::Magenta; }
+	virtual UClass* GetSupportedClass() const override { return UShaderResourceBuffer::StaticClass(); }
+	virtual uint32 GetCategories() override { return AssetCategory; }
+    
+private:
+    EAssetTypeCategories::Type AssetCategory;
+};

--- a/Source/ENDEditor/Public/ENDEditorModule.h
+++ b/Source/ENDEditor/Public/ENDEditorModule.h
@@ -12,4 +12,9 @@ public:
 private:
 	class FAssetTypeActions_EndEmissiveColorSettings* AssetAction;
 	class FAssetTypeActions_EffectAppendixMesh* AssetAction2;
+	class FAssetTypeActions_EndCameraSequence* AssetAction3;
+	class FAssetTypeActions_EndCinemaSequence* AssetAction4;
+	class FAssetTypeActions_EndAnimSet* AssetAction5;
+	class FAssetTypeActions_EndAssetPack* AssetAction6;
+	class FAssetTypeActions_ShaderResourceBuffer* AssetAction7;
 };

--- a/Source/ENDEditor/Public/EndAnimSet_Factory.h
+++ b/Source/ENDEditor/Public/EndAnimSet_Factory.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Factories/Factory.h"
+#include "EditorReimportHandler.h"
+#include "EndAnimSet_Factory.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ENDEDITOR_API UEndAnimSet_Factory : public UFactory
+{
+	GENERATED_BODY()
+	
+		UEndAnimSet_Factory();
+	virtual uint32 GetMenuCategories() const override;
+	virtual FText GetDisplayName() const override;
+	virtual UObject* FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Cntext, FFeedbackContext* Warn) override;
+	virtual bool ShouldShowInNewMenu() const override;
+	virtual UObject* FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled) override;
+};

--- a/Source/ENDEditor/Public/EndAssetPack_Factory.h
+++ b/Source/ENDEditor/Public/EndAssetPack_Factory.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Factories/Factory.h"
+#include "EditorReimportHandler.h"
+#include "EndAssetPack_Factory.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ENDEDITOR_API UEndAssetPack_Factory : public UFactory
+{
+	GENERATED_BODY()
+	
+	UEndAssetPack_Factory();
+	virtual uint32 GetMenuCategories() const override;
+	virtual FText GetDisplayName() const override;
+	virtual UObject* FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Cntext, FFeedbackContext* Warn) override;
+	virtual bool ShouldShowInNewMenu() const override;
+	virtual UObject* FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled) override;
+};

--- a/Source/ENDEditor/Public/EndCameraSequence_Factory.h
+++ b/Source/ENDEditor/Public/EndCameraSequence_Factory.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Factories/Factory.h"
+#include "EditorReimportHandler.h"
+#include "EndCameraSequence_Factory.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ENDEDITOR_API UEndCameraSequence_Factory : public UFactory
+{
+	GENERATED_BODY()
+	
+	UEndCameraSequence_Factory();
+	virtual uint32 GetMenuCategories() const override;
+	virtual FText GetDisplayName() const override;
+	virtual UObject* FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Cntext, FFeedbackContext* Warn) override;
+	virtual bool ShouldShowInNewMenu() const override;
+	virtual UObject* FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled) override;
+};

--- a/Source/ENDEditor/Public/EndCinemaSequence_Factory.h
+++ b/Source/ENDEditor/Public/EndCinemaSequence_Factory.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Factories/Factory.h"
+#include "EditorReimportHandler.h"
+#include "EndCinemaSequence_Factory.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ENDEDITOR_API UEndCinemaSequence_Factory : public UFactory
+{
+	GENERATED_BODY()
+	
+	UEndCinemaSequence_Factory();
+	virtual uint32 GetMenuCategories() const override;
+	virtual FText GetDisplayName() const override;
+	virtual UObject* FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Cntext, FFeedbackContext* Warn) override;
+	virtual bool ShouldShowInNewMenu() const override;
+	virtual UObject* FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled) override;
+};

--- a/Source/ENDEditor/Public/ShaderResourceBuffer_Factory.h
+++ b/Source/ENDEditor/Public/ShaderResourceBuffer_Factory.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Factories/Factory.h"
+#include "EditorReimportHandler.h"
+#include "ShaderResourceBuffer_Factory.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class ENDEDITOR_API UShaderResourceBuffer_Factory : public UFactory
+{
+	GENERATED_BODY()
+	
+	UShaderResourceBuffer_Factory();
+	virtual uint32 GetMenuCategories() const override;
+	virtual FText GetDisplayName() const override;
+	virtual UObject* FactoryCreateNew(UClass* InClass, UObject* InParent, FName InName, EObjectFlags Flags, UObject* Cntext, FFeedbackContext* Warn) override;
+	virtual bool ShouldShowInNewMenu() const override;
+	virtual UObject* FactoryCreateBinary(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, const TCHAR* Type, const uint8*& Buffer, const uint8* BufferEnd, FFeedbackContext* Warn, bool& bOutOperationCanceled) override;
+};


### PR DESCRIPTION
Factories for the following assets have been added:

-EndAnimSet
-EndAssetPack
-EndCameraSequence
-EndCinemaSequence
-ShaderResourceBuffer
-BonamikWindAsset
-HSFLipMap
-HSFLipSyncDataPack

Added a new Editor Mode for HSF stuff, right now it parses LipMaps from JSONs exported using FModel, it will later be used to import actual custom data that users create outside of Unreal.